### PR TITLE
Remove unused connections map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 # Changelog
 
 -  Added GetPipelines functionality in relation to ServerManager
+-  Remove `connections` map as it was unused and causing concurrent map write panics

--- a/websocket.go
+++ b/websocket.go
@@ -78,15 +78,8 @@ type threadsafeSubscriberMap struct {
 	lock        sync.RWMutex
 }
 
-var connections = make(map[string]*Connection)
-
 func NewConnection(host string) (*Connection, error) {
-	// if connections[host] != nil {
-	// 	return connections[host]
-	// }
-
 	c := new(Connection)
-	connections[host] = c
 
 	c.clientMap = threadsafeClientMap{
 		clients: make(map[float64]chan Response),


### PR DESCRIPTION
This map was not locked so would panic on concurrent map writes when NewConnection was called in a go routine but was never read from so I removed it