### PR TITLE
Add GetGstreamerDot() function to media elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 -  Remove `connections` map as it was unused and causing concurrent map write panics
 -  Fix goroutine management to match conventions
 -  Return error from connection.Request func to surface websocket errors correctly
+-  Add GetGstreamerDot() function to media elements

--- a/base.go
+++ b/base.go
@@ -113,7 +113,6 @@ func (elem *MediaObject) GetGstreamerDot() (string, error) {
 		if response.Error != nil {
 			return "", errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
-		// fmt.Println("RESP", string(response.Result.value))
 	case <-elem.connection.closeSig:
 		return "", ErrConnectionClosing
 	}

--- a/base.go
+++ b/base.go
@@ -1,6 +1,7 @@
 package kurento
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"reflect"
@@ -89,6 +90,40 @@ func (elem *MediaObject) Create(m IMediaObject, options map[string]interface{}) 
 		m.setId(trimQuotes(string(res.Result.Value)))
 	}
 	return res.Error
+}
+
+// Starts to send data to the endpoint `MediaSource`
+func (elem *MediaObject) GetGstreamerDot() (string, error) {
+	req := elem.getInvokeRequest()
+
+	req["params"] = map[string]interface{}{
+		"operation": "getElementGstreamerDot",
+		"object":    elem.Id,
+	}
+
+	// Call server and wait response
+	responses, err := elem.connection.Request(req)
+	if err != nil {
+		return "", err
+	}
+	var response Response
+	select {
+	case response = <-responses:
+		// Returns error or nil
+		if response.Error != nil {
+			return "", errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
+		}
+		// fmt.Println("RESP", string(response.Result.value))
+	case <-elem.connection.closeSig:
+		return "", ErrConnectionClosing
+	}
+	dot, err := response.Result.Value.MarshalJSON()
+
+	if err != nil {
+		return "", err
+	}
+	return string(dot), nil
+
 }
 
 // Create an object in memory that represents a remote object without creating it


### PR DESCRIPTION
Add a GetGstreamerDot function.

This get's the dotfile as a string, which we can use to analyse if the gstreamer pipeline is the problem when we can't hear audio.
