### PR TITLE
handle nil interface error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+### Go ###
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+### Go Patch ###
+/vendor/
+/Godeps/
+
+.DS_Store
+.vscode/
+.idea/
+
+*.env
+bin/
+tmp/

--- a/AlphaBlending.go
+++ b/AlphaBlending.go
@@ -54,7 +54,7 @@ func (elem *AlphaBlending) SetMaster(source HubPort, zOrder int) error {
 	}
 	select {
 	case response := <-responses:
-		if response.Error.IsNil() {
+		if !response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:
@@ -91,7 +91,7 @@ func (elem *AlphaBlending) SetPortProperties(relativeX float64, relativeY float6
 	}
 	select {
 	case response := <-responses:
-		if response.Error.IsNil() {
+		if !response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:

--- a/AlphaBlending.go
+++ b/AlphaBlending.go
@@ -54,7 +54,7 @@ func (elem *AlphaBlending) SetMaster(source HubPort, zOrder int) error {
 	}
 	select {
 	case response := <-responses:
-		if response.Error != nil {
+		if response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:
@@ -91,7 +91,7 @@ func (elem *AlphaBlending) SetPortProperties(relativeX float64, relativeY float6
 	}
 	select {
 	case response := <-responses:
-		if response.Error != nil {
+		if response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:

--- a/Dispatcher.go
+++ b/Dispatcher.go
@@ -53,7 +53,7 @@ func (elem *Dispatcher) Connect(source HubPort, sink HubPort) error {
 	select {
 	case response := <-responses:
 		// Returns error or nil
-		if response.Error != nil {
+		if response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:

--- a/Dispatcher.go
+++ b/Dispatcher.go
@@ -53,7 +53,7 @@ func (elem *Dispatcher) Connect(source HubPort, sink HubPort) error {
 	select {
 	case response := <-responses:
 		// Returns error or nil
-		if response.Error.IsNil() {
+		if !response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:

--- a/DispatcherOneToMany.go
+++ b/DispatcherOneToMany.go
@@ -53,7 +53,7 @@ func (elem *DispatcherOneToMany) SetSource(source HubPort) error {
 	select {
 	case response := <-responses:
 		// Returns error or nil
-		if response.Error != nil {
+		if response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:
@@ -81,7 +81,7 @@ func (elem *DispatcherOneToMany) RemoveSource() error {
 	select {
 	case response := <-responses:
 		// Returns error or nil
-		if response.Error != nil {
+		if response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:

--- a/DispatcherOneToMany.go
+++ b/DispatcherOneToMany.go
@@ -53,7 +53,7 @@ func (elem *DispatcherOneToMany) SetSource(source HubPort) error {
 	select {
 	case response := <-responses:
 		// Returns error or nil
-		if response.Error.IsNil() {
+		if !response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:
@@ -81,7 +81,7 @@ func (elem *DispatcherOneToMany) RemoveSource() error {
 	select {
 	case response := <-responses:
 		// Returns error or nil
-		if response.Error.IsNil() {
+		if !response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:

--- a/HttpEndpoint.go
+++ b/HttpEndpoint.go
@@ -101,7 +101,7 @@ func (elem *HttpEndpoint) GetUrl() (string, error) {
 		return "", ErrConnectionClosing
 	}
 	// // The url as a String
-	if response.Error.IsNil() {
+	if !response.Error.IsNil() {
 		return "", errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 	}
 	return trimQuotes(string(response.Result.Value)), nil

--- a/HttpEndpoint.go
+++ b/HttpEndpoint.go
@@ -101,7 +101,7 @@ func (elem *HttpEndpoint) GetUrl() (string, error) {
 		return "", ErrConnectionClosing
 	}
 	// // The url as a String
-	if response.Error != nil {
+	if response.Error.IsNil() {
 		return "", errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 	}
 	return trimQuotes(string(response.Result.Value)), nil

--- a/Mixer.go
+++ b/Mixer.go
@@ -56,7 +56,7 @@ func (elem *Mixer) Connect(media MediaType, source HubPort, sink HubPort) error 
 	select {
 	case response := <-responses:
 		// Returns error or nil
-		if response.Error.IsNil() {
+		if !response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:
@@ -92,7 +92,7 @@ func (elem *Mixer) Disconnect(media MediaType, source HubPort, sink HubPort) err
 	select {
 	case response := <-responses:
 		// Returns error or nil
-		if response.Error.IsNil() {
+		if !response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:

--- a/Mixer.go
+++ b/Mixer.go
@@ -56,7 +56,7 @@ func (elem *Mixer) Connect(media MediaType, source HubPort, sink HubPort) error 
 	select {
 	case response := <-responses:
 		// Returns error or nil
-		if response.Error != nil {
+		if response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:
@@ -92,7 +92,7 @@ func (elem *Mixer) Disconnect(media MediaType, source HubPort, sink HubPort) err
 	select {
 	case response := <-responses:
 		// Returns error or nil
-		if response.Error != nil {
+		if response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:

--- a/PlayerEndpoint.go
+++ b/PlayerEndpoint.go
@@ -50,7 +50,7 @@ func (elem *PlayerEndpoint) Play() error {
 	select {
 	case response := <-responses:
 		// Returns error or nil
-		if response.Error != nil {
+		if response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:

--- a/PlayerEndpoint.go
+++ b/PlayerEndpoint.go
@@ -50,7 +50,7 @@ func (elem *PlayerEndpoint) Play() error {
 	select {
 	case response := <-responses:
 		// Returns error or nil
-		if response.Error.IsNil() {
+		if !response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:

--- a/RecorderEndpoint.go
+++ b/RecorderEndpoint.go
@@ -50,7 +50,7 @@ func (elem *RecorderEndpoint) Record() error {
 	select {
 	case response := <-responses:
 		// Returns error or nil
-		if response.Error != nil {
+		if response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:

--- a/RecorderEndpoint.go
+++ b/RecorderEndpoint.go
@@ -50,7 +50,7 @@ func (elem *RecorderEndpoint) Record() error {
 	select {
 	case response := <-responses:
 		// Returns error or nil
-		if response.Error.IsNil() {
+		if !response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:

--- a/WebrtcEndpoint.go
+++ b/WebrtcEndpoint.go
@@ -57,7 +57,7 @@ func (elem *WebRtcEndpoint) GatherCandidates() error {
 	case response := <-responses:
 		// Otherwise we want to wait for the other candidates
 		// Returns error or nil
-		if response.Error.IsNil() {
+		if !response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:
@@ -92,7 +92,7 @@ func (elem *WebRtcEndpoint) AddIceCandidate(candidate IceCandidate) error {
 	select {
 	case response := <-responses:
 		// Returns error or nil
-		if response.Error.IsNil() {
+		if !response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:

--- a/WebrtcEndpoint.go
+++ b/WebrtcEndpoint.go
@@ -57,7 +57,7 @@ func (elem *WebRtcEndpoint) GatherCandidates() error {
 	case response := <-responses:
 		// Otherwise we want to wait for the other candidates
 		// Returns error or nil
-		if response.Error != nil {
+		if response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:
@@ -92,7 +92,7 @@ func (elem *WebRtcEndpoint) AddIceCandidate(candidate IceCandidate) error {
 	select {
 	case response := <-responses:
 		// Returns error or nil
-		if response.Error != nil {
+		if response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:

--- a/base.go
+++ b/base.go
@@ -90,9 +90,9 @@ func (elem *MediaObject) Create(m IMediaObject, options map[string]interface{}) 
 		m.setId(trimQuotes(string(res.Result.Value)))
 	}
 	if !res.Error.IsNil() {
-		return nil
+		return res.Error
 	}
-	return res.Error
+	return nil
 }
 
 // Starts to send data to the endpoint `MediaSource`

--- a/base.go
+++ b/base.go
@@ -89,7 +89,7 @@ func (elem *MediaObject) Create(m IMediaObject, options map[string]interface{}) 
 		//m.setParent(elem)
 		m.setId(trimQuotes(string(res.Result.Value)))
 	}
-	if res.Error.IsNil() {
+	if !res.Error.IsNil() {
 		return nil
 	}
 	return res.Error

--- a/base.go
+++ b/base.go
@@ -89,6 +89,9 @@ func (elem *MediaObject) Create(m IMediaObject, options map[string]interface{}) 
 		//m.setParent(elem)
 		m.setId(trimQuotes(string(res.Result.Value)))
 	}
+	if res.Error.IsNil() {
+		return nil
+	}
 	return res.Error
 }
 
@@ -110,7 +113,7 @@ func (elem *MediaObject) GetGstreamerDot() (string, error) {
 	select {
 	case response = <-responses:
 		// Returns error or nil
-		if response.Error != nil {
+		if response.Error.IsNil() {
 			return "", errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:

--- a/base.go
+++ b/base.go
@@ -113,7 +113,7 @@ func (elem *MediaObject) GetGstreamerDot() (string, error) {
 	select {
 	case response = <-responses:
 		// Returns error or nil
-		if response.Error.IsNil() {
+		if !response.Error.IsNil() {
 			return "", errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:

--- a/core.go
+++ b/core.go
@@ -512,7 +512,7 @@ func (elem *SdpEndpoint) ProcessOffer(offer string) (string, error) {
 	if !response.Error.IsNil() {
 		return "", errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 	}
-	return trimQuotes(string(response.Result.Value)), nil
+	return string(response.Result.Value), nil
 
 }
 

--- a/core.go
+++ b/core.go
@@ -169,7 +169,7 @@ func (elem *ServerManager) GetPipelines() ([]string, error) {
 	case <-elem.connection.closeSig:
 		return nil, ErrConnectionClosing
 	}
-	if response.Error.IsNil() {
+	if !response.Error.IsNil() {
 		return nil, fmt.Errorf("[%d] Error getting pipelnes: %s | %s", response.Error.Code, response.Error.Message, response.Error.Data)
 	}
 
@@ -336,7 +336,7 @@ func (elem *UriEndpoint) Pause() error {
 	select {
 	case response := <-responses:
 		// Returns error or nil
-		if response.Error.IsNil() {
+		if !response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:
@@ -362,7 +362,7 @@ func (elem *UriEndpoint) Stop() error {
 	select {
 	case response := <-responses:
 		// Returns error or nil
-		if response.Error.IsNil() {
+		if !response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:
@@ -410,7 +410,7 @@ func (elem *MediaObject) SetLatencyStats(value bool) error {
 	}
 	select {
 	case response := <-responses:
-		if response.Error.IsNil() {
+		if !response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:
@@ -472,7 +472,7 @@ func (elem *SdpEndpoint) GenerateOffer() (string, error) {
 	}
 	// fmt.Println(response.Result["value"])
 	// // The SDP offer.
-	if response.Error.IsNil() {
+	if !response.Error.IsNil() {
 		return "", errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 	}
 	return trimQuotes(string(response.Result.Value)), nil
@@ -509,7 +509,7 @@ func (elem *SdpEndpoint) ProcessOffer(offer string) (string, error) {
 	}
 
 	// // The chosen configuration from the ones stated in the SDP offer
-	if response.Error.IsNil() {
+	if !response.Error.IsNil() {
 		return "", errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 	}
 	return trimQuotes(string(response.Result.Value)), nil
@@ -546,7 +546,7 @@ func (elem *SdpEndpoint) ProcessAnswer(answer string) (string, error) {
 	}
 
 	// // Updated SDP offer, based on the answer received.
-	if response.Error.IsNil() {
+	if !response.Error.IsNil() {
 		return "", errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 	}
 	return trimQuotes(string(response.Result.Value)), nil
@@ -581,7 +581,7 @@ func (elem *SdpEndpoint) GetLocalSessionDescriptor() (string, error) {
 	}
 
 	// // The last agreed SessionSpec
-	if response.Error.IsNil() {
+	if !response.Error.IsNil() {
 		return "", errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 	}
 	return trimQuotes(string(response.Result.Value)), nil
@@ -614,7 +614,7 @@ func (elem *SdpEndpoint) GetRemoteSessionDescriptor() (string, error) {
 	}
 
 	// // The last agreed User Agent session description
-	if response.Error.IsNil() {
+	if !response.Error.IsNil() {
 		return "", errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 	}
 	return trimQuotes(string(response.Result.Value)), nil
@@ -711,7 +711,7 @@ func (elem *MediaElement) GetSourceConnections(mediaType MediaType, description 
 	// // The list will be empty if no sources are found.
 
 	ret := []ElementConnectionData{}
-	if response.Error.IsNil() {
+	if !response.Error.IsNil() {
 		return nil, errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 	}
 	return &ret, nil
@@ -753,7 +753,7 @@ func (elem *MediaElement) GetSinkConnections(mediaType MediaType, description st
 	// // element. The list will be empty if no sinks are found.
 
 	ret := []ElementConnectionData{}
-	if response.Error.IsNil() {
+	if !response.Error.IsNil() {
 		return nil, errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 	}
 	return &ret, nil
@@ -789,7 +789,7 @@ func (elem *MediaElement) Connect(sink IMediaElement, mediaType MediaType, sourc
 	case response := <-responses:
 
 		// Returns error or nil
-		if response.Error.IsNil() {
+		if !response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:
@@ -827,7 +827,7 @@ func (elem *MediaElement) Disconnect(sink IMediaElement, mediaType MediaType, so
 	select {
 	case response := <-responses:
 		// Returns error or nil
-		if response.Error.IsNil() {
+		if !response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:
@@ -861,7 +861,7 @@ func (elem *MediaElement) SetAudioFormat(caps AudioCaps) error {
 	select {
 	case response := <-responses:
 		// Returns error or nil
-		if response.Error.IsNil() {
+		if !response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:
@@ -895,7 +895,7 @@ func (elem *MediaElement) SetVideoFormat(caps VideoCaps) error {
 	select {
 	case response := <-responses:
 		// Returns error or nil
-		if response.Error.IsNil() {
+		if !response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:
@@ -930,7 +930,7 @@ func (elem *MediaElement) GetStats() (map[string]ElementStats, error) {
 		return nil, ErrConnectionClosing
 	}
 	// Check for error first
-	if response.Error.IsNil() {
+	if !response.Error.IsNil() {
 		return nil, errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 	}
 	// Otherwise should try to get stuff

--- a/core.go
+++ b/core.go
@@ -62,7 +62,7 @@ func (elem *MediaObject) Subscribe(eventType string, handler SubscriptionHandler
 	case <-elem.connection.closeSig:
 		return ErrConnectionClosing
 	}
-	if message.Error != nil {
+	if message.Error.IsNil() {
 		log.Println("Error trying to subscribe to " + eventType)
 		return errors.New(fmt.Sprintf("[%d] %s %s", message.Error.Code, message.Error.Message, message.Error.Data))
 	}
@@ -76,7 +76,7 @@ func (elem *MediaObject) Subscribe(eventType string, handler SubscriptionHandler
 	}()
 
 	// Returns error or nil
-	if message.Error != nil {
+	if message.Error.IsNil() {
 		return errors.New(fmt.Sprintf("[%d] %s %s", message.Error.Code, message.Error.Message, message.Error.Data))
 	}
 	return nil
@@ -106,7 +106,7 @@ func (elem *MediaObject) Release() error {
 	case <-elem.connection.closeSig:
 		return ErrConnectionClosing
 	}
-	if message.Error != nil {
+	if message.Error.IsNil() {
 		log.Println("Error trying to release " + elem.Id)
 		return errors.New(fmt.Sprintf("[%d] %s %s", message.Error.Code, message.Error.Message, message.Error.Data))
 	}
@@ -115,7 +115,7 @@ func (elem *MediaObject) Release() error {
 	}
 
 	// Returns error or nil
-	if message.Error != nil {
+	if message.Error.IsNil() {
 		return errors.New(fmt.Sprintf("[%d] %s %s", message.Error.Code, message.Error.Message, message.Error.Data))
 	}
 	return nil
@@ -169,7 +169,7 @@ func (elem *ServerManager) GetPipelines() ([]string, error) {
 	case <-elem.connection.closeSig:
 		return nil, ErrConnectionClosing
 	}
-	if response.Error != nil {
+	if response.Error.IsNil() {
 		return nil, fmt.Errorf("[%d] Error getting pipelnes: %s | %s", response.Error.Code, response.Error.Message, response.Error.Data)
 	}
 
@@ -336,7 +336,7 @@ func (elem *UriEndpoint) Pause() error {
 	select {
 	case response := <-responses:
 		// Returns error or nil
-		if response.Error != nil {
+		if response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:
@@ -362,7 +362,7 @@ func (elem *UriEndpoint) Stop() error {
 	select {
 	case response := <-responses:
 		// Returns error or nil
-		if response.Error != nil {
+		if response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:
@@ -410,7 +410,7 @@ func (elem *MediaObject) SetLatencyStats(value bool) error {
 	}
 	select {
 	case response := <-responses:
-		if response.Error != nil {
+		if response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:
@@ -472,7 +472,7 @@ func (elem *SdpEndpoint) GenerateOffer() (string, error) {
 	}
 	// fmt.Println(response.Result["value"])
 	// // The SDP offer.
-	if response.Error != nil {
+	if response.Error.IsNil() {
 		return "", errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 	}
 	return trimQuotes(string(response.Result.Value)), nil
@@ -509,7 +509,7 @@ func (elem *SdpEndpoint) ProcessOffer(offer string) (string, error) {
 	}
 
 	// // The chosen configuration from the ones stated in the SDP offer
-	if response.Error != nil {
+	if response.Error.IsNil() {
 		return "", errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 	}
 	return trimQuotes(string(response.Result.Value)), nil
@@ -546,7 +546,7 @@ func (elem *SdpEndpoint) ProcessAnswer(answer string) (string, error) {
 	}
 
 	// // Updated SDP offer, based on the answer received.
-	if response.Error != nil {
+	if response.Error.IsNil() {
 		return "", errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 	}
 	return trimQuotes(string(response.Result.Value)), nil
@@ -581,7 +581,7 @@ func (elem *SdpEndpoint) GetLocalSessionDescriptor() (string, error) {
 	}
 
 	// // The last agreed SessionSpec
-	if response.Error != nil {
+	if response.Error.IsNil() {
 		return "", errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 	}
 	return trimQuotes(string(response.Result.Value)), nil
@@ -614,7 +614,7 @@ func (elem *SdpEndpoint) GetRemoteSessionDescriptor() (string, error) {
 	}
 
 	// // The last agreed User Agent session description
-	if response.Error != nil {
+	if response.Error.IsNil() {
 		return "", errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 	}
 	return trimQuotes(string(response.Result.Value)), nil
@@ -711,7 +711,7 @@ func (elem *MediaElement) GetSourceConnections(mediaType MediaType, description 
 	// // The list will be empty if no sources are found.
 
 	ret := []ElementConnectionData{}
-	if response.Error != nil {
+	if response.Error.IsNil() {
 		return nil, errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 	}
 	return &ret, nil
@@ -753,7 +753,7 @@ func (elem *MediaElement) GetSinkConnections(mediaType MediaType, description st
 	// // element. The list will be empty if no sinks are found.
 
 	ret := []ElementConnectionData{}
-	if response.Error != nil {
+	if response.Error.IsNil() {
 		return nil, errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 	}
 	return &ret, nil
@@ -789,7 +789,7 @@ func (elem *MediaElement) Connect(sink IMediaElement, mediaType MediaType, sourc
 	case response := <-responses:
 
 		// Returns error or nil
-		if response.Error != nil {
+		if response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:
@@ -827,7 +827,7 @@ func (elem *MediaElement) Disconnect(sink IMediaElement, mediaType MediaType, so
 	select {
 	case response := <-responses:
 		// Returns error or nil
-		if response.Error != nil {
+		if response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:
@@ -861,7 +861,7 @@ func (elem *MediaElement) SetAudioFormat(caps AudioCaps) error {
 	select {
 	case response := <-responses:
 		// Returns error or nil
-		if response.Error != nil {
+		if response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:
@@ -895,7 +895,7 @@ func (elem *MediaElement) SetVideoFormat(caps VideoCaps) error {
 	select {
 	case response := <-responses:
 		// Returns error or nil
-		if response.Error != nil {
+		if response.Error.IsNil() {
 			return errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 		}
 	case <-elem.connection.closeSig:
@@ -930,7 +930,7 @@ func (elem *MediaElement) GetStats() (map[string]ElementStats, error) {
 		return nil, ErrConnectionClosing
 	}
 	// Check for error first
-	if response.Error != nil {
+	if response.Error.IsNil() {
 		return nil, errors.New(fmt.Sprintf("[%d] %s %s", response.Error.Code, response.Error.Message, response.Error.Data))
 	}
 	// Otherwise should try to get stuff

--- a/core.go
+++ b/core.go
@@ -62,7 +62,7 @@ func (elem *MediaObject) Subscribe(eventType string, handler SubscriptionHandler
 	case <-elem.connection.closeSig:
 		return ErrConnectionClosing
 	}
-	if message.Error.IsNil() {
+	if !message.Error.IsNil() {
 		log.Println("Error trying to subscribe to " + eventType)
 		return errors.New(fmt.Sprintf("[%d] %s %s", message.Error.Code, message.Error.Message, message.Error.Data))
 	}
@@ -76,7 +76,7 @@ func (elem *MediaObject) Subscribe(eventType string, handler SubscriptionHandler
 	}()
 
 	// Returns error or nil
-	if message.Error.IsNil() {
+	if !message.Error.IsNil() {
 		return errors.New(fmt.Sprintf("[%d] %s %s", message.Error.Code, message.Error.Message, message.Error.Data))
 	}
 	return nil
@@ -106,7 +106,7 @@ func (elem *MediaObject) Release() error {
 	case <-elem.connection.closeSig:
 		return ErrConnectionClosing
 	}
-	if message.Error.IsNil() {
+	if !message.Error.IsNil() {
 		log.Println("Error trying to release " + elem.Id)
 		return errors.New(fmt.Sprintf("[%d] %s %s", message.Error.Code, message.Error.Message, message.Error.Data))
 	}
@@ -115,7 +115,7 @@ func (elem *MediaObject) Release() error {
 	}
 
 	// Returns error or nil
-	if message.Error.IsNil() {
+	if !message.Error.IsNil() {
 		return errors.New(fmt.Sprintf("[%d] %s %s", message.Error.Code, message.Error.Message, message.Error.Data))
 	}
 	return nil

--- a/websocket.go
+++ b/websocket.go
@@ -26,6 +26,10 @@ func (e *Error) Error() string {
 	return e.Message
 }
 
+func (e *Error) IsNil() bool {
+	return e == nil
+}
+
 // Response represents server response
 type Response struct {
 	Jsonrpc string


### PR DESCRIPTION
When I use library, I get a problem with Error handling. The Error pointer in Response struct always return not nil error interface which return a *kurento.Error pointer inside the interface ([Go FAQ: nil error](https://go.dev/doc/faq#nil_error)). Therefore, I receive an error although it not really nil when I call some functions. Ex

```
func main() {
	var (
		host       = "ws://localhost:8888"
		pipeline = new(kurento.MediaPipeline)
		master   = new(kurento.WebRtcEndpoint)
	)
	kurento.SetDebug(true)
	server, err := kurento.NewConnection(host)
	if err != nil {
		logrus.Panic(err)
	}

	if err = server.Create(pipeline, nil); err != nil {
		fmt.Printf("pipeline err %#v, %#v\n", err, nil)
	}
...

}
```
The console output

`pipeline err (*kurento.Error)(nil)`